### PR TITLE
Import ExitStack and partial from the standard library modules

### DIFF
--- a/defer.py
+++ b/defer.py
@@ -56,9 +56,14 @@ def defers(func: Callable) -> Callable:
         ))
         # should probably make both those inserts some other way, later..
         tree.body[0].body.insert(0, ast.ImportFrom(
-                                        module='defer',
+                                        module='contextlib',
                                         names=[
                                             ast.alias(name='ExitStack'),
+                                        ],
+                                        level=0))
+        tree.body[0].body.insert(0, ast.ImportFrom(
+                                        module='functools',
+                                        names=[
                                             ast.alias(name='partial'),
                                         ],
                                         level=0))


### PR DESCRIPTION
Hi, thanks for the funny module.

### Problem
The appended import statement raises an ImportError when the `defer` module's name differs from `defer.defer`, for example, when it's imported from other directories.

Test output from ipython:
```
[ins] In [1]: from defer.defer import defers

[ins] In [2]: @defers
         ...: def foo():
         ...:     defer: print()
         ...:

[ins] In [3]: foo()
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[3], line 1
----> 1 foo()

File ~/path/to/defer/defer.py:79, in defers.<locals>.wrapped(*args, **kwargs)
     77 tree = ast.fix_missing_locations(tree)
     78 func.__code__ = compile(tree, '<ast>', 'exec').co_consts[0]
---> 79 return func(*args, **kwargs)

File <ast>:2, in foo()

ImportError: cannot import name 'ExitStack' from 'defer' (unknown location)
```

### Solution
I split the import statement and let idents be imported from standard library.

Test output from ipython, with the patch I propose:
```
[ins] In [1]: from defer.defer import defers

[ins] In [2]: @defers
         ...: def foo():
         ...:     defer: print('success')
         ...:

[ins] In [3]: foo()
success
```

### P.S.
I'm having so much fun with this black magic module. Keep it up.